### PR TITLE
Documentation improvements, foodcritic and subdirectives support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: false
+language: ruby
+cache: bundler
+rvm:
+  - 2.0
+  - 2.1
+  - 2.2
+install: bundle install --binstubs
+script: "foodcritic -P -f any ."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is used to list changes made in each version of the caddy cookbook.
 - Gabriel Mazetto - Improved documentation and CHANGELOG
 - Gabriel Mazetto - Foodcritic on Travis CI
 - Gabriel Mazetto - Added subdirective to the template (to enable rewrite rules on hosts)
+- Gabriel Mazetto - Use Upstart for Ubuntu LTS (14.04)
 
 0.3.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,24 @@ caddy CHANGELOG
 
 This file is used to list changes made in each version of the caddy cookbook.
 
+0.4.0 (UNRELEASED)
+-----
+- Gabriel Mazetto - Improved documentation and CHANGELOG
+- Gabriel Mazetto - Foodcritic on Travis CI
+
+0.3.0
+-----
+- Christian Fischer - Improved cookbook metadata
+- Christian Fischer - Fixes for sysV init system
+
+0.2.0
+-----
+- Christian Fischer - Caddyfile template generated based on cookbook attributes
+- Christian Fischer - Init systems support (sysv systemd upstart)
+
 0.1.0
 -----
-- [your_name] - Initial release of caddy
+- Christian Fischer - Initial release of caddy
 
 - - -
 Check the [Markdown Syntax Guide](http://daringfireball.net/projects/markdown/syntax) for help with Markdown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is used to list changes made in each version of the caddy cookbook.
 -----
 - Gabriel Mazetto - Improved documentation and CHANGELOG
 - Gabriel Mazetto - Foodcritic on Travis CI
+- Gabriel Mazetto - Added subdirective to the template (to enable rewrite rules on hosts)
 
 0.3.0
 -----

--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,6 @@ gem 'berkshelf'
 #   gem "vagrant-omnibus", github: "schisamo/vagrant-omnibus"
 # end
 
-gem "test-kitchen"
-gem "kitchen-vagrant"
+gem 'test-kitchen'
+gem 'kitchen-vagrant'
+gem 'foodcritic'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 caddy Cookbook
 ==============
 
+[![Cookbook Version](https://img.shields.io/cookbook/v/caddy.svg)](https://supermarket.chef.io/cookbooks/caddy)
+
 This cookbook installs and runs caddy webserver https://caddyserver.com
 
 
@@ -92,4 +94,7 @@ e.g.
 
 License and Authors
 -------------------
-Authors: TODO: List authors
+
+Authors:
+- Christian Fischer
+- Gabriel Mazetto

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,3 @@
+def caddy_letsencrypt_arguments
+  node['caddy']['email'] ? "-agree -email #{node['caddy']['email']}" : ''
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -44,7 +44,7 @@ end
 
 variables = ({
   :command => 'caddy',
-  :options => "-agree -email #{node['caddy']['email']} -pidfile /var/run/caddy.pid -log /usr/local/caddy/caddy.log -conf /etc/Caddyfile"
+  :options => "#{caddy_letsencrypt_arguments} -pidfile /var/run/caddy.pid -log /usr/local/caddy/caddy.log -conf /etc/Caddyfile"
 })
 
 if %w(arch gentoo rhel fedora suse).include? node['platform_family']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,8 +23,7 @@
 # Caddyfile at /etc/Caddyfile
 # pidfile at /var/run/caddy.pid
 
-
-ark 'caddy' do 
+ark 'caddy' do
   url "https://caddyserver.com/download/build?os=linux&arch=amd64&features=#{node['caddy']['features'].join(',')}"
   extension 'tar.gz'
   has_binaries ['./caddy']
@@ -35,7 +34,7 @@ end
 execute 'setcap cap_net_bind_service=+ep caddy' do
   cwd '/usr/local/caddy'
   action :nothing
-  subscribes :run, 'ark[caddy]',:immediately
+  subscribes :run, 'ark[caddy]', :immediately
 end
 
 template '/etc/Caddyfile' do
@@ -55,6 +54,13 @@ if %w(arch gentoo rhel fedora suse).include? node['platform_family']
     mode '0755'
     variables variables
   end
+elsif node['platform'] == 'ubuntu' && node['platform_version'] == '14.04'
+  # Upstart
+  template '/etc/init/caddy.conf' do
+    source 'upstart.erb'
+    mode '0755'
+    variables variables
+  end
 else
   # SysV
   template '/etc/init.d/caddy' do
@@ -66,4 +72,5 @@ end
 
 service 'caddy' do
   action [:enable, :start]
+  supports :status => true, :start => true, :stop => true, :restart => true
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -58,7 +58,7 @@ elsif node['platform'] == 'ubuntu' && node['platform_version'] == '14.04'
   # Upstart
   template '/etc/init/caddy.conf' do
     source 'upstart.erb'
-    mode '0755'
+    mode '0644'
     variables variables
   end
 else

--- a/templates/default/Caddyfile.erb
+++ b/templates/default/Caddyfile.erb
@@ -1,7 +1,15 @@
 <% @hosts.each do |host, directives| %>
 <%= host %> <% if directives %> {
   <% directives.each do |directive, value| %>
+    <% if value.is_a? Hash %>
+  <%= directive %> {
+      <% value.each do |subdirective, value| %>
+    <%= subdirective %> <%= value %>
+      <% end %>
+  }
+    <% else %>
   <%= directive %> <%= value %>
+    <% end %>
   <% end %>
 }
 <% end %>


### PR DESCRIPTION
I've made some improvements to your chef recipe documentation, added foodcritic using travis, and did a small fix to allow "subdirectives" into the template.

To give you some context, I'm using this recipe to configure a host for wordpress. One of the requirements is to be able to add a "rewrite" directive inside the "host" like this one:

```
rewrite {
  if    {path} not_match ^\/wp-admin
  to    {path} {path}/ /index.php?_url={uri}
}
```

Added upstart to Ubuntu 14.04