### PR TITLE
Fix systemd caddy service on CentOS 7

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -43,13 +43,13 @@ template '/etc/Caddyfile' do
 end
 
 variables = ({
-  :command => 'caddy',
+  :command => '/usr/local/bin/caddy',
   :options => "#{caddy_letsencrypt_arguments} -pidfile /var/run/caddy.pid -log /usr/local/caddy/caddy.log -conf /etc/Caddyfile"
 })
 
 if %w(arch gentoo rhel fedora suse).include? node['platform_family']
   # Systemd
-  template '/etc/system.d/caddy' do
+  template '/etc/systemd/system/caddy.service' do
     source 'systemd.erb'
     mode '0755'
     variables variables


### PR DESCRIPTION
When I run test-kitchen currently I get:

```
         * template[/etc/system.d/caddy] action create
           * Parent directory /etc/system.d does not exist.
           ================================================================================
           Error executing action `create` on resource 'template[/etc/system.d/caddy]'
           ================================================================================
           
           Chef::Exceptions::EnclosingDirectoryDoesNotExist
           ------------------------------------------------
           Parent directory /etc/system.d does not exist.
           
           Resource Declaration:
           ---------------------
           # In /tmp/kitchen/cookbooks/caddy/recipes/default.rb
           
            52:   template '/etc/system.d/caddy' do
            53:     source 'systemd.erb'
            54:     mode '0755'
            55:     variables variables
            56:   end
            57: elsif node['platform'] == 'ubuntu' && node['platform_version'] == '14.04'
           
           Compiled Resource:
           ------------------
           # Declared in /tmp/kitchen/cookbooks/caddy/recipes/default.rb:52:in `from_file'
           
           template("/etc/system.d/caddy") do
             action [:create]
             retries 0
             retry_delay 2
             default_guard_interpreter :default
             source "systemd.erb"
             variables {:command=>"caddy", :options=>"-agree -email caddy@example.com -pidfile /var/run/caddy.pid -log /usr/local/caddy/caddy.log -conf /etc/Caddyfile"}
             declared_type :template
             cookbook_name :caddy
             recipe_name "default"
             mode "0755"
             atomic_update true
             path "/etc/system.d/caddy"
           end
           
       
           
           ================================================================================
           Error executing action `restart` on resource 'service[caddy]'
           ================================================================================
           
           Mixlib::ShellOut::ShellCommandFailed
           ------------------------------------
           Expected process to exit with [0], but received '6'
           ---- Begin output of /bin/systemctl restart caddy ----
           STDOUT: 
           STDERR: Failed to issue method call: Unit caddy.service failed to load: No such file or directory.
           ---- End output of /bin/systemctl restart caddy ----
           Ran /bin/systemctl restart caddy returned 6
           
           Resource Declaration:
           ---------------------
           # In /tmp/kitchen/cookbooks/caddy/recipes/default.rb
           
            73: service 'caddy' do
            74:   action [:enable, :start]
            75:   supports :status => true, :start => true, :stop => true, :restart => true
            76: end
           
           Compiled Resource:
           ------------------
           # Declared in /tmp/kitchen/cookbooks/caddy/recipes/default.rb:73:in `from_file'
           
           service("caddy") do
             action [:enable, :start]
             supports {:status=>true, :start=>true, :stop=>true, :restart=>true}
             retries 0
             retry_delay 2
             default_guard_interpreter :default
             service_name "caddy"
             pattern "caddy"
             declared_type :service
             cookbook_name :caddy
             recipe_name "default"
           end
```

This PR is to address the error.