### PR TITLE
Use systemd to manage caddy on newer ubuntu

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,14 +1,15 @@
 ---
 driver:
   name: vagrant
-  network: 
-    - ["forwarded_port", {guest: 8080, host: 8080}] 
-    - ["forwarded_port", {guest: 80, host: 80}] 
+  network:
+    - ["forwarded_port", {guest: 8080, host: 8080}]
+    - ["forwarded_port", {guest: 80, host: 80}]
 
 provisioner:
   name: chef_solo
 
 platforms:
+  - name: ubuntu-15.04
   - name: ubuntu-14.04
   - name: centos-7.1
 
@@ -22,7 +23,7 @@ suites:
           - cors
           - git
         email: caddy@example.com
-        hosts: 
+        hosts:
           localhost:8080:
           localhost:
             log: localhost.log

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -43,13 +43,13 @@ template '/etc/Caddyfile' do
 end
 
 variables = ({
-  :command => 'caddy',
+  :command => '/usr/local/bin/caddy',
   :options => "#{caddy_letsencrypt_arguments} -pidfile /var/run/caddy.pid -log /usr/local/caddy/caddy.log -conf /etc/Caddyfile"
 })
 
 if %w(arch gentoo rhel fedora suse).include? node['platform_family']
   # Systemd
-  template '/etc/system.d/caddy' do
+  template '/etc/systemd/system/caddy.service' do
     source 'systemd.erb'
     mode '0755'
     variables variables

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -47,7 +47,8 @@ variables = ({
   :options => "#{caddy_letsencrypt_arguments} -pidfile /var/run/caddy.pid -log /usr/local/caddy/caddy.log -conf /etc/Caddyfile"
 })
 
-if %w(arch gentoo rhel fedora suse).include? node['platform_family']
+if %w(arch gentoo rhel fedora suse).include?(node['platform_family']) ||
+   (node['platform'] == 'ubuntu' && node['platform_version'] >= '15.04')
   # Systemd
   template '/etc/systemd/system/caddy.service' do
     source 'systemd.erb'


### PR DESCRIPTION
Systemd is becoming the default init system in ubuntu.  This PR builds on #3 and adds logic to use systemd on ubuntu >= 15.04

https://wiki.ubuntu.com/SystemdForUpstartUsers